### PR TITLE
Fix error in dequeueing seeds in `greedyalign'

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,3 @@
-julia 0.6
+julia 1.0
 LinearMaps 1.0
 DataStructures

--- a/src/IsoRank.jl
+++ b/src/IsoRank.jl
@@ -177,9 +177,9 @@ function greedyalign(R::AbstractMatrix,seeds=Vector{Tuple{Int,Int}}();
     for k = 1:length(seeds)
         i,j = seeds[k]
         f[i] = j
+        for ip = setdiff(1:n1,L1); dequeue!(Q,(ip,j)); end
         push!(L1,i)
         push!(L2,j)
-        for ip = setdiff(1:n1,L1); dequeue!(Q,(ip,j)); end
         for jp = setdiff(1:n2,L2); dequeue!(Q,(i,jp)); end
     end
     println("Building priority queue")


### PR DESCRIPTION
Little bug that likely only pops up in datasets which are small. Simple fix that just ensures that the original seed tuple is removed from the queue.